### PR TITLE
feat: add missing field on txs

### DIFF
--- a/sse/types.go
+++ b/sse/types.go
@@ -27,29 +27,26 @@ type MatchMakerEvent struct {
 
 // PendingTransaction represents the hits revealed by the matchmaker about the transaction / bundle
 type PendingTransaction struct {
-	To               common.Address `json:"to"`
-	FunctionSelector [4]byte        `json:"functionSelector,omitempty"`
-	CallData         []byte         `json:"callData,omitempty"` // Could be replaces with geth.hexutil type
-	MevGasPrice      *hexutil.Big   `json:"mevGasPrice,omitempty"`
-	GasUsed          *hexutil.Big   `json:"gasUsed,omitempty"`
+	Hash             *common.Hash    `json:"hash,omitempty"`
+	To               *common.Address `json:"to,omitempty"`
+	FunctionSelector [4]byte         `json:"functionSelector,omitempty"`
+	CallData         []byte          `json:"callData,omitempty"`
 }
 
 // UnmarshalJSON unmarshals JSON data into a PendingTransaction
 func (t *PendingTransaction) UnmarshalJSON(data []byte) error {
 	var temp struct {
-		To               common.Address `json:"to"`
-		FunctionSelector string         `json:"functionSelector,omitempty"`
-		CallData         string         `json:"callData,omitempty"`
-		MevGasPrice      *hexutil.Big   `json:"mevGasPrice,omitempty"`
-		GasUsed          *hexutil.Big   `json:"gasUsed,omitempty"`
+		Hash             *common.Hash    `json:"hash,omitempty"`
+		To               *common.Address `json:"to"`
+		FunctionSelector string          `json:"functionSelector,omitempty"`
+		CallData         string          `json:"callData,omitempty"`
 	}
 	if err := json.Unmarshal(data, &temp); err != nil {
 		return err
 	}
 
-	t.MevGasPrice = temp.MevGasPrice
-	t.GasUsed = temp.GasUsed
 	t.To = temp.To
+	t.Hash = temp.Hash
 
 	if temp.CallData != "" && temp.CallData != "0x" {
 		decoded, err := hex.DecodeString(strings.TrimPrefix(temp.CallData, "0x"))

--- a/sse/types_test.go
+++ b/sse/types_test.go
@@ -3,7 +3,6 @@ package sse
 import (
 	"encoding/json"
 	"errors"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,24 +14,21 @@ func TestPendingTransaction_UnmarshalJSON(t *testing.T) {
 		"to": "0x1234567890abcdef1234567890abcdef12345678",
 		"functionSelector": "0xabcdef12",
 		"callData": "0xdeadbeef",
-		"mevGasPrice": "0x1000000000000",
-		"gasUsed": "0x200000"
+		"hash": "0x42bfaa1a6ec6f136a970f102871de727dc3f9c29c0dcc9409fe54de2c60358b1"
 	}`
 
 	expectedTo := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	expectedHash := common.HexToHash("0x42bfaa1a6ec6f136a970f102871de727dc3f9c29c0dcc9409fe54de2c60358b1")
 	expectedFunctionSelector := [4]byte{0xab, 0xcd, 0xef, 0x12}
 	expectedCallData := []byte{0xde, 0xad, 0xbe, 0xef}
-	expectedMevGasPrice := big.NewInt(0x1000000000000)
-	expectedGasUsed := big.NewInt(0x200000)
 
 	var tx PendingTransaction
 	err := json.Unmarshal([]byte(rawJSON), &tx)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedTo, tx.To)
+	assert.Equal(t, expectedTo.Cmp(*tx.To), 0)
+	assert.Equal(t, expectedHash.Cmp(*tx.Hash), 0)
 	assert.Equal(t, expectedFunctionSelector, tx.FunctionSelector)
 	assert.Equal(t, expectedCallData, tx.CallData)
-	assert.Equal(t, expectedMevGasPrice.String(), tx.MevGasPrice.ToInt().String())
-	assert.Equal(t, expectedGasUsed.String(), tx.GasUsed.ToInt().String())
 }
 
 func TestPendingTransaction_UnmarshalJSON_EmptyFields(t *testing.T) {
@@ -40,45 +36,41 @@ func TestPendingTransaction_UnmarshalJSON_EmptyFields(t *testing.T) {
 		"to": "0x1234567890abcdef1234567890abcdef12345678",
 		"functionSelector": "",
 		"callData": "",
-		"mevGasPrice": "0x0",
-		"gasUsed": "0x0"
+		"hash": "0x42bfaa1a6ec6f136a970f102871de727dc3f9c29c0dcc9409fe54de2c60358b1"
 	}`
 
 	expectedTo := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	expectedHash := common.HexToHash("0x42bfaa1a6ec6f136a970f102871de727dc3f9c29c0dcc9409fe54de2c60358b1")
 	expectedFunctionSelector := [4]byte{}
 	var expectedCallData []byte
-	expectedMevGasPrice := big.NewInt(0)
-	expectedGasUsed := big.NewInt(0)
 
 	var tx PendingTransaction
 	err := json.Unmarshal([]byte(rawJSON), &tx)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedTo, tx.To)
+	assert.Equal(t, expectedTo.Cmp(*tx.To), 0)
+	assert.Equal(t, expectedHash.Cmp(*tx.Hash), 0)
 	assert.Equal(t, expectedFunctionSelector, tx.FunctionSelector)
 	assert.Equal(t, expectedCallData, tx.CallData)
-	assert.Equal(t, expectedMevGasPrice.String(), tx.MevGasPrice.ToInt().String())
-	assert.Equal(t, expectedGasUsed.String(), tx.GasUsed.ToInt().String())
 }
 
 func TestPendingTransaction_UnmarshalJSON_MissingFields(t *testing.T) {
 	rawJSON := `{
-		"to": "0x1234567890abcdef1234567890abcdef12345678"
+		"to": "0x1234567890abcdef1234567890abcdef12345678",
+		"hash": "0x42bfaa1a6ec6f136a970f102871de727dc3f9c29c0dcc9409fe54de2c60358b1"
 	}`
 
 	expectedTo := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	expectedHash := common.HexToHash("0x42bfaa1a6ec6f136a970f102871de727dc3f9c29c0dcc9409fe54de2c60358b1")
 	var expectedFunctionSelector [4]byte
 	var expectedCallData []byte
-	var expectedMevGasPrice *big.Int
-	var expectedGasUsed *big.Int
 
 	var tx PendingTransaction
 	err := json.Unmarshal([]byte(rawJSON), &tx)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedTo, tx.To)
+	assert.Equal(t, expectedTo.Cmp(*tx.To), 0)
+	assert.Equal(t, expectedHash.Cmp(*tx.Hash), 0)
 	assert.Equal(t, expectedFunctionSelector, tx.FunctionSelector)
 	assert.Equal(t, expectedCallData, tx.CallData)
-	assert.Equal(t, expectedMevGasPrice.String(), tx.MevGasPrice.ToInt().String())
-	assert.Equal(t, expectedGasUsed.String(), tx.GasUsed.ToInt().String())
 }
 
 func TestEvent_Data_Error(t *testing.T) {


### PR DESCRIPTION
## 📝 Summary
Add missing `hash` in `txs`
<!--- A general summary of your changes -->
I see you are missing `hash` in `txs` when fetching the event from sse.
## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Change `PendingTransaction` to fit with the specs from `mev-share-node`
## 📚 References
https://github.com/flashbots/mev-share-node/blob/main/mevshare/types.go#L109
<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `make fmt`
* [x] `go mod tidy`
